### PR TITLE
[Fix #61] MyBlog - status 수정

### DIFF
--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/post/controller/ApiV1PostCreateController.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/post/controller/ApiV1PostCreateController.java
@@ -21,18 +21,19 @@ import java.util.Optional;
 public class ApiV1PostCreateController {
     private final PostService postService;
     private final UserRepository userRepository;
+
     // 게시글 등록
     @PostMapping
     public ResponseEntity<String> createPost(
             @RequestBody @Validated PostRequestDto dto,
             @AuthenticationPrincipal SecurityUser userDetails) {
 
-        postService.createPost(dto, userDetails.getId()); // getUsername() → getId()
+        postService.createPost(dto, userDetails.getId());
         return ResponseEntity.ok("게시글 등록 완료");
     }
 
     // 현재 로그인한 사용자가 마지막으로 저장한 임시 글을 불러오는 API
-    @GetMapping("/posts/drafts/latest")
+    @GetMapping("/drafts/latest")
     public ResponseEntity<PostResponseDto> getLatestDraft(@AuthenticationPrincipal SecurityUser userDetails) {
         // userId 꺼냄
         long userId = userDetails.getId();
@@ -45,7 +46,7 @@ public class ApiV1PostCreateController {
         Optional<Post> draftOpt = postService.getLatestDraftByUser(user);
 
         if (draftOpt.isEmpty()) {
-            return ResponseEntity.noContent().build(); // 임시 글 없을 경우 204
+            return ResponseEntity.noContent().build();
         }
 
         PostResponseDto dto = new PostResponseDto(draftOpt.get());

--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/post/controller/ApiV1PostReadController.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/post/controller/ApiV1PostReadController.java
@@ -14,7 +14,7 @@ public class ApiV1PostReadController {
     private final PostService postService;
 
     // 게시글 전체 목록 보기
-    @GetMapping("/posts")
+    @GetMapping
     public Page<PostResponseDto> getAllPosts(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
@@ -40,7 +40,7 @@ public class ApiV1PostReadController {
     }
 
     // 카테고리별로 보는 API
-    @GetMapping("/posts/category/{categoryId}")
+    @GetMapping("/category/{categoryId}")
     public ResponseEntity<Page<PostResponseDto>> getPostsByCategory(
             @PathVariable Long categoryId,
             @RequestParam(value = "page", defaultValue = "0") int page,

--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/post/dto/PostDTO.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/post/dto/PostDTO.java
@@ -17,8 +17,6 @@ public class PostDTO {
     private String title;
     private String content;
     private LocalDateTime createdAt;
-    private int views;
-    private int likes;
 
 
 
@@ -28,9 +26,7 @@ public class PostDTO {
                 post.getUser().getId(),
                 post.getTitle(),
                 post.getContent(),
-                post.getCreatedAt(),
-                post.getViews(),
-                post.getLikes()
+                post.getCreatedAt()
         );
     }
 

--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/post/entity/PostStatus.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/post/entity/PostStatus.java
@@ -1,5 +1,5 @@
 package com.commitmate.re_cord.domain.post.post.entity;
 
 public enum PostStatus {
-    DRAFT, PUBLISHED
+    DRAFT, PUBLISHED, DELETED
 }

--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/post/repository/PostRepository.java
@@ -1,10 +1,8 @@
 package com.commitmate.re_cord.domain.post.post.repository;
 
-import com.commitmate.re_cord.domain.post.post.dto.PostDTO;
 import com.commitmate.re_cord.domain.post.post.entity.Post;
 import com.commitmate.re_cord.domain.post.post.entity.PostStatus;
 import com.commitmate.re_cord.domain.user.user.entity.User;
-import com.commitmate.re_cord.global.jpa.UpdateStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,7 +12,6 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
 
 public interface PostRepository extends JpaRepository<Post,Long> {
 
@@ -59,15 +56,16 @@ public interface PostRepository extends JpaRepository<Post,Long> {
 
     List<Object[]> getMonthlyViews(@Param("userId") Long userId);
 
-    
+    // 게시물의 상태중에서 updateAt이 가장 최신인 글을 가져오는 메서드
     Optional<Post> findTopByUserAndStatusOrderByUpdatedAtDesc(User user, PostStatus status);
-    // 카테고리와 PUBLISHED 인 게시글만 보는 메서드
-    Page<Post> findAllByCategoryIdAndUpdateStatus(Long categoryId, UpdateStatus updateStatus, Pageable pageable);
 
-    // 제목, 내용, 작성자 이름을 기준으로 검색하되, 삭제되지 않은 포스트만 필터링하는 메서드
+    // 카테고리와 PUBLISHED 인 게시글만 보는 메서드
+    Page<Post> findAllByCategoryIdAndStatus(Long categoryId, PostStatus status, Pageable pageable);
+
+    // 제목, 내용, 작성자 이름을 기준으로 검색하고, 상태가 EDITED 인 게시물만 가져오는 메서드
     @Query("""
     SELECT p FROM Post p
-    WHERE p.updateStatus = 'EDITED'
+    WHERE p.status = 'PUBLISHED'
       AND (
         LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
         LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
@@ -76,10 +74,13 @@ public interface PostRepository extends JpaRepository<Post,Long> {
 """)
     Page<Post> searchVisiblePosts(@Param("keyword") String keyword, Pageable pageable);
 
+    // 상태가 EDITED 인 게시물만 가져오는 메서드
+    Page<Post> findAllByStatus(PostStatus status, Pageable pageable);
 
-    // 삭제되지 않은 모든 포스트를 찾는 메서드
-    Page<Post> findAllByUpdateStatus(UpdateStatus updateStatus, Pageable pageable);
+    // 특정 시간이 지난 게시물을 가져오는 메서드
+    List<Post> findAllByStatusAndUpdatedAtBefore(PostStatus status, LocalDateTime time);
 
-    List<Post> findAllByUpdateStatusAndUpdatedAtBefore(UpdateStatus status, LocalDateTime time);
+    // 특정 유저의 특정 상태의 게시물을 삭제하는 메서드
+    void deleteByUserAndStatus(User user, PostStatus status);
 
 }

--- a/backend/src/main/java/com/commitmate/re_cord/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/commitmate/re_cord/global/config/SwaggerConfig.java
@@ -1,0 +1,27 @@
+package com.commitmate.re_cord.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public classSwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info().title("API 문서").version("v1"))
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        ))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+    }
+}

--- a/backend/src/main/java/com/commitmate/re_cord/global/jpa/UpdateStatus.java
+++ b/backend/src/main/java/com/commitmate/re_cord/global/jpa/UpdateStatus.java
@@ -4,8 +4,7 @@ public enum UpdateStatus {
     NOT_EDITED(0,false,"미작성"),
     EDITED(1,true,"작성 완료"),
     TEMP_SAVED(2,false,"임시 저장"),
-    DELETED(3, false, "삭제"),
-    UPDATED(4, true, "수정 완료");
+    UPDATED(3, true, "수정 완료");
     private final int code;
     private final boolean edited;
     private final String description;

--- a/backend/src/main/java/com/commitmate/re_cord/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/commitmate/re_cord/global/security/SecurityConfig.java
@@ -31,6 +31,8 @@ public class SecurityConfig {
                                 .permitAll()
                                 .requestMatchers("/h2-console/**")
                                 .permitAll()
+                                .requestMatchers("/api/**")
+                                .authenticated()
                                 .anyRequest()
                                 .permitAll()
                 )

--- a/backend/src/main/java/com/commitmate/re_cord/scheduler/PostCleanupScheduler.java
+++ b/backend/src/main/java/com/commitmate/re_cord/scheduler/PostCleanupScheduler.java
@@ -1,6 +1,7 @@
 package com.commitmate.re_cord.scheduler;
 
 import com.commitmate.re_cord.domain.post.post.entity.Post;
+import com.commitmate.re_cord.domain.post.post.entity.PostStatus;
 import com.commitmate.re_cord.domain.post.post.repository.PostRepository;
 import com.commitmate.re_cord.global.jpa.UpdateStatus;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,7 @@ public class PostCleanupScheduler {
     @Scheduled(cron = "0 0 3 * * *")
     public void deleteOldSoftDeletedPosts() {
         LocalDateTime threshold = LocalDateTime.now().minusDays(15);
-        List<Post> oldDeletedPosts = postRepository.findAllByUpdateStatusAndUpdatedAtBefore(UpdateStatus.DELETED, threshold);
+        List<Post> oldDeletedPosts = postRepository.findAllByStatusAndUpdatedAtBefore(PostStatus.DELETED, threshold);
 
         postRepository.deleteAll(oldDeletedPosts);
         System.out.println("[Scheduler] 하드 삭제된 게시글 수: " + oldDeletedPosts.size());


### PR DESCRIPTION

## 이슈 넘버 기술 

Closes # 61

## 작업 내용
 
- 로그인한 사용자가 Draft 상태로 임시저장을 하면 그전에 있던 그 사용자의 Draft 글은 자동 삭제 -> 임시저장 글은 제일 최신 거만 볼 수 있음
- updateStatus를 이용해 조회하는 걸 PostStatus를 이용해 조회하는 걸로 수정 

특이사항(나중에 수정하거나 없애도 되는 것들) 
- swagger Authorize 버튼 활성화하기 위해 global.config에 SwaggerConfig 생성
- securityConfig에서 모든 요청이 허용으로 설정되어 security가 검사하지 않고 그냥 넘겨 securityUser가 채워지지 않기 때문에 
  필터에  .requestMatchers("/api/**").authenticated() 추가
---------------------------------------------------------------------------
swagger로 test한 후 전부 잘 작동해서 PR