### PR TITLE
[FIX #79] 엑세스 토큰리턴 변경, 로그인 dto 변경

### DIFF
--- a/backend/src/main/java/com/commitmate/re_cord/domain/user/user/service/UserService.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/user/user/service/UserService.java
@@ -71,7 +71,8 @@ public class UserService {
                 userRepository.save(user);
 
                 String accessToken = authTokenService.genAccessToken(user);
-                return user.getRefreshToken() + " " + accessToken;
+//                return user.getRefreshToken() + " " + accessToken;    // 사용자에게 엑세스 토큰만
+                return "Bearer " + accessToken;
             }
         }
 

--- a/backend/src/main/java/com/commitmate/re_cord/global/security/UserLoginDto.java
+++ b/backend/src/main/java/com/commitmate/re_cord/global/security/UserLoginDto.java
@@ -20,9 +20,9 @@ public class UserLoginDto {
     @NotNull(message = "비밀번호는 필수입니다.")
     @ValidPassword
     private String password;
-    @NotNull(message = "사용자 이름은 필수입니다.")
-    private String username;
-    @Size(max = 100, message = "부트캠프명은 100자 이하여야 합니다.")
-    private String bootcamp;
-    private String role;
+//    @NotNull(message = "사용자 이름은 필수입니다.")
+//    private String username;
+//    @Size(max = 100, message = "부트캠프명은 100자 이하여야 합니다.")
+//    private String bootcamp;
+//    private String role;
 }


### PR DESCRIPTION

## 이슈 넘버 기술 

Closes # 79

## 작업 내용
 
- 엑세스 토큰리턴을 Bearer + (엑세스 토큰)으로 변경해 스웨거에서 로그인 시 바로 붙여넣으면 됨
- 로그인 dto를 이메일, 비밀번호로 변경

