### PR TITLE
[FIX] 로그인 dto 수정, 소셜 로그인 시 액세스 토큰 부여

### DIFF
--- a/backend/src/main/java/com/commitmate/re_cord/domain/user/user/controller/ApiV1UserController.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/user/user/controller/ApiV1UserController.java
@@ -82,8 +82,7 @@ public class ApiV1UserController {
                 dto.getGeneration()
         );
 
-        String accessToken = rq.getCookieValue("accessToken");
-//        String accessToken = userService.genAccessToken(user);
+        String accessToken = userService.genAccessToken(user);
 
         return ResponseEntity.ok(Map.of(
                 "accessToken", accessToken,

--- a/backend/src/main/java/com/commitmate/re_cord/global/security/UserLoginDto.java
+++ b/backend/src/main/java/com/commitmate/re_cord/global/security/UserLoginDto.java
@@ -20,9 +20,5 @@ public class UserLoginDto {
     @NotNull(message = "비밀번호는 필수입니다.")
     @ValidPassword
     private String password;
-    @NotNull(message = "사용자 이름은 필수입니다.")
-    private String username;
-    @Size(max = 100, message = "부트캠프명은 100자 이하여야 합니다.")
-    private String bootcamp;
-    private String role;
 }
+


### PR DESCRIPTION

## 이슈 넘버 기술 

Closes # 82

## 작업 내용
 
- 로그인 dto 수정 -> 이메일, 패스워드만 받도록
- 소셜 로그인 시 액세스 토큰 부여

