### PR TITLE
[FEAT #121] 대댓글 기능 구현

### DIFF
--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/controller/ApiV1CommentController.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/controller/ApiV1CommentController.java
@@ -59,16 +59,28 @@ public class ApiV1CommentController {
     @Operation(
             summary = "댓글 좋아요 누르기"
     )
+//    @PostMapping("/{commentId}/likes")
+//    public ResponseEntity<Void> toggleCommentLike(
+//            @PathVariable Long postId,
+//            @PathVariable Long commentId,
+//            @AuthenticationPrincipal SecurityUser userDetails
+//    ){
+//        Long userId = userDetails.getId();
+//        commentVoteService.toggleCommentLike(postId, commentId, userId);
+//        return ResponseEntity.ok().build();
+//    }
     @PostMapping("/{commentId}/likes")
-    public ResponseEntity<Void> toggleCommentLike(
+    public ResponseEntity<Map<String, Boolean>> toggleCommentLike(
             @PathVariable Long postId,
             @PathVariable Long commentId,
             @AuthenticationPrincipal SecurityUser userDetails
-    ){
+    ) {
         Long userId = userDetails.getId();
-        commentVoteService.toggleCommentLike(postId, commentId, userId);
-        return ResponseEntity.ok().build();
+
+        boolean liked = commentVoteService.toggleCommentLike(postId, commentId, userId);
+        return ResponseEntity.ok(Map.of("liked", liked));
     }
+
 
     @Operation(
             summary = "댓글 수정"

--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/controller/ApiV1CommentController.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/controller/ApiV1CommentController.java
@@ -59,16 +59,7 @@ public class ApiV1CommentController {
     @Operation(
             summary = "댓글 좋아요 누르기"
     )
-//    @PostMapping("/{commentId}/likes")
-//    public ResponseEntity<Void> toggleCommentLike(
-//            @PathVariable Long postId,
-//            @PathVariable Long commentId,
-//            @AuthenticationPrincipal SecurityUser userDetails
-//    ){
-//        Long userId = userDetails.getId();
-//        commentVoteService.toggleCommentLike(postId, commentId, userId);
-//        return ResponseEntity.ok().build();
-//    }
+
     @PostMapping("/{commentId}/likes")
     public ResponseEntity<Map<String, Boolean>> toggleCommentLike(
             @PathVariable Long postId,

--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/dto/CommentRequestDTO.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/dto/CommentRequestDTO.java
@@ -13,5 +13,7 @@ public class CommentRequestDTO {
     @NotBlank(message = "빈 댓글은 등록할 수 없습니다.")
     @Size(max=200, message = "댓글은 최대 200자까지 등록 가능합니다.")
     private String content;
+    private Long parentId; // nullable
+
 
 }

--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/dto/CommentResponseDTO.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/dto/CommentResponseDTO.java
@@ -1,31 +1,13 @@
 package com.commitmate.re_cord.domain.post.comment.comment.dto;
 
 import com.commitmate.re_cord.domain.post.comment.comment.entity.Comment;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-import java.time.LocalDateTime;
-
-//@Getter
-//@AllArgsConstructor
-//@NoArgsConstructor
-//public class CommentResponseDTO {
-//    private Long id;
-//    private String content;
-//    private String username;
-//    private String createdAt;
-//
-//    public CommentResponseDTO(Comment comment) {
-//        this.id = comment.getId();
-//        this.content = comment.getContent();
-//        this.username = comment.getUser().getUsername();
-//        this.createdAt = comment.getCreatedAt().toString();
-//    }
-//}
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class CommentResponseDTO {
@@ -36,14 +18,18 @@ public class CommentResponseDTO {
     private String updateStatus;
     private String profileImageUrl;
     private int likes;
+    private Long parentId;
+    private List<CommentResponseDTO> replies;
 
     public CommentResponseDTO(Comment comment) {
         this.id = comment.getId();
-        this.content = comment.getContent();
+        this.content = comment.isDeleted() ? "삭제된 댓글입니다." : comment.getContent(); //Soft Delete
         this.username = comment.getUser().getUsername();
         this.createdAt = comment.getCreatedAt().toString();
         this.updateStatus = comment.getUpdateStatus().name();
         this.profileImageUrl = comment.getUser().getProfileImageUrl();
         this.likes = comment.getLikes();
+        this.parentId = comment.getParent() != null ? comment.getParent().getId() : null;
+        this.replies = new ArrayList<>();
     }
 }

--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/dto/CommentResponseDTO.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/dto/CommentResponseDTO.java
@@ -35,6 +35,7 @@ public class CommentResponseDTO {
     private String createdAt;
     private String updateStatus;
     private String profileImageUrl;
+    private int likes;
 
     public CommentResponseDTO(Comment comment) {
         this.id = comment.getId();
@@ -43,5 +44,6 @@ public class CommentResponseDTO {
         this.createdAt = comment.getCreatedAt().toString();
         this.updateStatus = comment.getUpdateStatus().name();
         this.profileImageUrl = comment.getUser().getProfileImageUrl();
+        this.likes = comment.getLikes();
     }
 }

--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/entity/Comment.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/entity/Comment.java
@@ -23,6 +23,10 @@ public class Comment extends BaseEntity {
     private int likes;
     private String content;
 
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+
     @Enumerated(EnumType.STRING)
     private UpdateStatus updateStatus = UpdateStatus.NOT_EDITED;
 
@@ -38,6 +42,11 @@ public class Comment extends BaseEntity {
     @OneToMany(mappedBy = "comment",cascade = CascadeType.REMOVE)
     private List<CommentVote> commentVotes;
 
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private Comment parent; //대댓글-부모댓글 필드 추가
+
+
     public void increaseLikeCount(){
         this.likes++;
     }
@@ -48,12 +57,13 @@ public class Comment extends BaseEntity {
         }
     }
 
-    public Comment(int likes, String content, UpdateStatus updateStatus, User user, Post post) {
+    public Comment(int likes, String content, UpdateStatus updateStatus, User user, Post post, Comment parent) {
         this.likes = likes;
         this.content = content;
         this.updateStatus = updateStatus;
         this.user = user;
         this.post = post;
+        this.parent = parent;
     }
 
 

--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/repository/CommentRepository.java
@@ -25,6 +25,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> orderCommentsByLikes(@Param("userId")Long userId);
 
     Page<Comment> findByPostId(Long postId, Pageable pageable);
+    Page<Comment> findByPostIdAndParentIsNull(Long postId, Pageable pageable);
+    List<Comment> findByPostIdAndParentIsNotNull(Long postId);
+
 
 
 

--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/service/CommentService.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/service/CommentService.java
@@ -13,16 +13,15 @@ import com.commitmate.re_cord.domain.user.user.repository.UserRepository;
 import com.commitmate.re_cord.global.jpa.UpdateStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.data.domain.Pageable;
 
 
-
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,14 +33,21 @@ public class CommentService {
     private final UserRepository userRepository;
 
     @Transactional
-    public CommentResponseDTO registerComment(CommentRequestDTO commentRequestDTO, Long postId, Long userId){
+    public CommentResponseDTO registerComment(CommentRequestDTO commentRequestDTO, Long postId, Long userId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(()->new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+
 
         User user = userRepository.findById(userId)
-                .orElseThrow(()-> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
 
-        Comment comment = new Comment(0,commentRequestDTO.getContent(), UpdateStatus.NOT_EDITED,user,post);
+        Comment parent = null;
+        if (commentRequestDTO.getParentId() != null) {
+            parent = commentRepository.findById(commentRequestDTO.getParentId())
+                    .orElseThrow(() -> new IllegalArgumentException("원 댓글이 존재하지 않습니다."));
+        }
+
+        Comment comment = new Comment(0, commentRequestDTO.getContent(), UpdateStatus.NOT_EDITED, user, post, parent);
         Comment savedComment = commentRepository.save(comment);
 
 
@@ -51,33 +57,35 @@ public class CommentService {
                 savedComment.getCreatedAt().toString(),
                 savedComment.getUpdateStatus().name(),
                 user.getProfileImageUrl(),
-                savedComment.getLikes());
+                savedComment.getLikes(),
+                savedComment.getParent() != null ? savedComment.getParent().getId() : null,
+                new ArrayList<>());
     }
 
     @Transactional
-    public void deleteComment(Long commentId, Long userId){
+    public void deleteComment(Long commentId, Long userId) {
 
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(()-> new IllegalArgumentException("해당 댓글이 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 댓글이 존재하지 않습니다."));
 
-        if(!comment.getUser().getId().equals(userId)){
+        if (!comment.getUser().getId().equals(userId)) {
             throw new IllegalArgumentException("댓글 작성자만 삭제할 수 있습니다.");
         }
-
-        commentRepository.delete(comment);
+        comment.setDeleted(true);
+        commentRepository.save(comment); //soft delete
 
     }
 
     @Transactional
-    public CommentResponseDTO updateComment(CommentRequestDTO commentRequestDTO, Long postId, Long userId, Long commentId){
+    public CommentResponseDTO updateComment(CommentRequestDTO commentRequestDTO, Long postId, Long userId, Long commentId) {
 
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(()-> new IllegalArgumentException("해당 댓글이 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 댓글이 존재하지 않습니다."));
 
         User user = userRepository.findById(userId)
-                .orElseThrow(()-> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
 
-        if(!comment.getUser().getId().equals(userId)){
+        if (!comment.getUser().getId().equals(userId)) {
             throw new IllegalArgumentException("댓글 작성자만 수정할 수 있습니다.");
         }
 
@@ -91,26 +99,40 @@ public class CommentService {
                 updatedComment.getCreatedAt().toString(),
                 updatedComment.getUpdateStatus().name(),
                 user.getProfileImageUrl(),
-                updatedComment.getLikes());
+                updatedComment.getLikes(),
+                updatedComment.getParent() != null ? updatedComment.getParent().getId() : null,
+                new ArrayList<>());
     }
 
-    @Transactional
-    public Page<CommentResponseDTO> getCommentByPostId(Long postId, int page, int size){
+    @Transactional(readOnly = true)
+    public Page<CommentResponseDTO> getCommentByPostId(Long postId, int page, int size) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(()->new IllegalArgumentException("해당 게시물이 존재하지 않습니다."));
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<Comment> commentPage = commentRepository.findByPostId(postId,pageable);
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시물이 존재하지 않습니다."));
 
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
+        Page<Comment> parentComments = commentRepository.findByPostIdAndParentIsNull(postId, pageable);
 
-        return commentPage.map(CommentResponseDTO::new);
-    }
+        //대댓글은 바로 지워지도록
+        List<Comment> allReplies = commentRepository.findByPostIdAndParentIsNotNull(postId);
+        Map<Long, List<CommentResponseDTO>> repliesGrouped = allReplies.stream()
+                .filter(reply -> !reply.isDeleted())
+                .map(CommentResponseDTO::new)
+                .sorted(Comparator.comparing(CommentResponseDTO::getCreatedAt))
+                .collect(Collectors.groupingBy(CommentResponseDTO::getParentId));
 
-    public List<CommentDTO> getCommentsByUser(Long userId) {
-        return commentRepository.findMyComment(userId).stream()
-                .map(CommentDTO::getEntity)
+        //대댓글이 없는 댓글은 바로 지워지도록
+        List<CommentResponseDTO> commentDTOs = parentComments.getContent().stream()
+                .filter(parent -> !(parent.isDeleted() && !repliesGrouped.containsKey(parent.getId())))
+                .map(parent -> {
+                    CommentResponseDTO dto = new CommentResponseDTO(parent);
+                    dto.setReplies(repliesGrouped.getOrDefault(parent.getId(), new ArrayList<>()));
+                    return dto;
+                })
                 .collect(Collectors.toList());
 
+        return new PageImpl<>(commentDTOs, pageable, parentComments.getTotalElements());
     }
+
 
 
 }

--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/service/CommentService.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/comment/service/CommentService.java
@@ -45,7 +45,13 @@ public class CommentService {
         Comment savedComment = commentRepository.save(comment);
 
 
-        return new CommentResponseDTO(savedComment.getId(), savedComment.getContent(),user.getUsername(),savedComment.getCreatedAt().toString(),savedComment.getUpdateStatus().name(),user.getProfileImageUrl());
+        return new CommentResponseDTO(savedComment.getId(),
+                savedComment.getContent(),
+                user.getUsername(),
+                savedComment.getCreatedAt().toString(),
+                savedComment.getUpdateStatus().name(),
+                user.getProfileImageUrl(),
+                savedComment.getLikes());
     }
 
     @Transactional
@@ -79,7 +85,13 @@ public class CommentService {
         comment.setUpdateStatus(UpdateStatus.EDITED);
 
         Comment updatedComment = commentRepository.save(comment);
-        return new CommentResponseDTO(updatedComment.getId(),updatedComment.getContent(),updatedComment.getUser().getUsername(),updatedComment.getCreatedAt().toString(),updatedComment.getUpdateStatus().name(),user.getProfileImageUrl());
+        return new CommentResponseDTO(updatedComment.getId(),
+                updatedComment.getContent(),
+                updatedComment.getUser().getUsername(),
+                updatedComment.getCreatedAt().toString(),
+                updatedComment.getUpdateStatus().name(),
+                user.getProfileImageUrl(),
+                updatedComment.getLikes());
     }
 
     @Transactional

--- a/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/commentVote/service/CommentVoteService.java
+++ b/backend/src/main/java/com/commitmate/re_cord/domain/post/comment/commentVote/service/CommentVoteService.java
@@ -26,7 +26,7 @@ public class CommentVoteService {
     private final CommentVoteRepository commentVoteRepository;
 
     @Transactional
-    public void toggleCommentLike(Long postId, Long commentId, Long userId){
+    public boolean toggleCommentLike(Long postId, Long commentId, Long userId){
         Post post = postRepository.findById(postId)
                 .orElseThrow(()->new IllegalArgumentException("존재하지 않는 게시글입니다."));
 
@@ -37,17 +37,22 @@ public class CommentVoteService {
                 .orElseThrow(()->new IllegalArgumentException("존재하지 않는 유저입니다."));
 
         Optional<CommentVote> isLike = commentVoteRepository.findByUserAndComment(user,comment);
+        boolean liked;
 
 
         if(isLike.isPresent()){
             commentVoteRepository.delete(isLike.get()); //좋아요 취소
             comment.decreaseLikeCount(); //추천 수 감소
+            liked=false;
         }else{
             CommentVote commentVote = new CommentVote(user, comment);
             commentVoteRepository.save(commentVote);
             comment.increaseLikeCount();
+            liked=true;
         }
         commentRepository.save(comment); //좋아요 수 저장
+
+        return liked;
 
 
     }


### PR DESCRIPTION

## 이슈 넘버 기술 

Closes #121

## 작업 내용
 
- 백엔드 대댓글 기능 구현
- 프론트에서도 보이도록
- 원댓글이 삭제되더라도 "댓글이 삭제되었습니다" 로 변경 후 답댓은 계속 보이도록(soft delete)
- 답댓은 삭제되면 바로 삭제
- 답댓이 없는 원댓은 바로 삭제
